### PR TITLE
Check for index pages in a slightly more efficient way

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -41,5 +41,6 @@
   "revision": "Revision",
   "date": "Date",
   "scores": "Scores",
-  "contest-in-progress": "This contest is currently in progress, and scores can only be viewed by the contest administrators."
+  "contest-in-progress": "This contest is currently in progress, and scores can only be viewed by the contest administrators.",
+  "reset-scores": "Reset scores"
 }

--- a/src/Controller/ContestsController.php
+++ b/src/Controller/ContestsController.php
@@ -252,6 +252,12 @@ class ContestsController extends Controller {
 		$indexPageIds = [];
 		foreach ( $indexPageUrls as $indexPageUrlString ) {
 			$indexPageUrl = urldecode( $indexPageUrlString );
+			// Do we already know about it?
+			$existingIndexPage = IndexPage::firstOrNew( [ 'url' => $indexPageUrl ] );
+			if ( $existingIndexPage->id ) {
+				$indexPageIds[] = $existingIndexPage->id;
+				continue;
+			}
 			// Check validity.
 			$wikisourceApi = new WikisourceApi();
 			$wikisource = $wikisourceApi->newWikisourceFromUrl( $indexPageUrl );

--- a/src/Entity/IndexPage.php
+++ b/src/Entity/IndexPage.php
@@ -65,6 +65,7 @@ class IndexPage extends Model {
 	 */
 	public function scopeNeedsScoring( Builder $query ) {
 		return $query
+			->has( 'contests' )
 			->doesntHave( 'scores' )
 			->orWhereHas( 'contests', function ( Builder $query ) {
 				return $query->inProgress();


### PR DESCRIPTION
1. When inserting index page URLs, check to see if they've already
   been inserted; and
2. When looking for index pages to score, exclude those that are
   not associated with any contests.