### PR TITLE
Avoid revisions with no pagequality user

### DIFF
--- a/src/Command/ScoreCommand.php
+++ b/src/Command/ScoreCommand.php
@@ -116,9 +116,14 @@ class ScoreCommand extends Command {
 		$oldTimestamp = false;
 		$oldQuality = false;
 		$oldUser = false;
+		$pattern = '|<pagequality level="(\d)" user="(.+?)" />|';
 		foreach ( $pageInfo['revisions'] as $rev ) {
 			$content = $rev['*'];
-			preg_match( '|<pagequality level="(\d)" user="(.*?)" />|', $content, $qualityMatches );
+			$matched = preg_match( $pattern, $content, $qualityMatches );
+			if ( $matched !== 1 ) {
+				// Some revisions don't have a pagequality user.
+				continue;
+			}
 			$quality = (int)$qualityMatches[1];
 			$userId = User::firstOrCreate( [ 'name' => $qualityMatches[2] ] )->id;
 			$timestamp = strtotime( $rev['timestamp'] );


### PR DESCRIPTION
There are some (old?) revisions that have no user associated with
the pagequality tag. This change updates the regex to ensure we
only look at those with a value for the username.

Bug: T251658