### PR TITLE
Remove start date restriction when retrieving revisions

### DIFF
--- a/src/Command/ScoreCommand.php
+++ b/src/Command/ScoreCommand.php
@@ -137,7 +137,7 @@ class ScoreCommand extends Command {
 	protected function processPage(
 		array $contest, MediawikiApi $api, string $pageTitle, int $indexPageId
 	) {
-		$cacheKey = 'revisions_' . $pageTitle . $contest['start_date'] . $contest['end_date'];
+		$cacheKey = 'revisions_' . $pageTitle . $contest['end_date'];
 		$cacheItem = $this->cache->getItem( md5( $cacheKey ) );
 		if ( $cacheItem->isHit() ) {
 			$response = $cacheItem->get();
@@ -149,7 +149,6 @@ class ScoreCommand extends Command {
 				->setParam( 'prop', 'revisions' )
 				->setParam( 'titles', $pageTitle )
 				->setParam( 'rvlimit', 5000 )
-				->setParam( 'rvstart', $contest['start_date'] )
 				->setParam( 'rvend', $contest['end_date'] )
 				->setParam( 'rvdir', 'newer' )
 				->setParam( 'rvprop', 'user|timestamp|content|ids' ) );


### PR DESCRIPTION
It is necessary to look at revisions before the start of a contest
in order to determine if they are changes in quality or not.

Bug: T309433