### PR TITLE
Add page titles to most pages

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -14,6 +14,7 @@
 
   "stats-summary": "$1 {{PLURAL:$1|person|people}} have taken part in $2 {{PLURAL:$2|contest|contests}}.",
 
+  "all-contests": "All contests",
   "create-contest": "Create contest",
   "edit-contest": "Edit contest configuration",
   "name-label": "Name:",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -13,6 +13,7 @@
 	"logged-in-as": "Informative sentence about the currently logged-in user. $1 is the username.",
 	"logout": "Link to log out.",
 	"stats-summary": "Summary sentence about the stats for the whole tool. $1 is the number of people; $2 is the number of contests.",
+	"all-contests": "Page title for the contest-list page.",
 	"create-contest": "Header text displayed above the contest-creation form.",
 	"edit-contest": "Header text displayed above the contest-editing form.",
 	"name-label": "Form label for the 'name' field.\n{{Identical|Name}}",

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -3,7 +3,11 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>{{ msg('app-title') }}</title>
+	<title>
+		{% block page_title %}
+		{% endblock %}
+		{{ msg('app-title') }}
+	</title>
 	{% block stylesheets %}
 		<link rel="stylesheet" href="//tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css" />
 	{% endblock %}

--- a/templates/contests.html.twig
+++ b/templates/contests.html.twig
@@ -1,5 +1,9 @@
 {% extends 'base.html.twig' %}
 
+{% block page_title %}
+    {{ msg('all-contests') }} —
+{% endblock %}
+
 {% block main %}
 
     <p>

--- a/templates/contests_edit.html.twig
+++ b/templates/contests_edit.html.twig
@@ -1,5 +1,9 @@
 {% extends 'base.html.twig' %}
 
+{% block page_title %}
+    {% if contest.id %}{{ msg('edit-contest') }}{% else %}{{ msg('create-contest') }}{% endif %} —
+{% endblock %}
+
 {% block main %}
 
     <h2>

--- a/templates/contests_view.html.twig
+++ b/templates/contests_view.html.twig
@@ -1,5 +1,9 @@
 {% extends 'base.html.twig' %}
 
+{% block page_title %}
+    {{ msg('contest', [contest.name]) }} —
+{% endblock %}
+
 {% block main %}
 
 <h2>{{ msg('contest', [contest.name]) }}</h2>

--- a/templates/contests_viewuser.html.twig
+++ b/templates/contests_viewuser.html.twig
@@ -1,5 +1,9 @@
 {% extends 'base.html.twig' %}
 
+{% block page_title %}
+    {{ user.name }} — {{ msg('contest', [contest.name]) }} —
+{% endblock %}
+
 {% block main %}
 
 <ol class="breadcrumb">


### PR DESCRIPTION
To make it easier to see what's what when one has multiple
WS Contest tabs open.