### PR TITLE
Fix summary sentence to handle numbers over 1000

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -12,7 +12,7 @@
   "logged-in-as": "You are logged in as $1",
   "logout": "Log out",
 
-  "stats-summary": "$1 {{PLURAL:$1|person|people}} have taken part in $2 {{PLURAL:$2|contest|contests}}.",
+  "stats-summary": "$1 {{PLURAL:$2|person|people}} have taken part in $3 {{PLURAL:$4|contest|contests}}.",
 
   "all-contests": "All contests",
   "create-contest": "Create contest",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -12,7 +12,7 @@
 	"login": "Link to log in.",
 	"logged-in-as": "Informative sentence about the currently logged-in user. $1 is the username.",
 	"logout": "Link to log out.",
-	"stats-summary": "Summary sentence about the stats for the whole tool. $1 is the number of people; $2 is the number of contests.",
+	"stats-summary": "Summary sentence about the stats for the whole tool. Parameters:\n\n* $1 — formatted number of people\n* $2 — unformatted number of people (for use with PLURAL)* $3 — formatted number of contests\n* $4 — unformatted number of contests (for use with PLURAL)",
 	"all-contests": "Page title for the contest-list page.",
 	"create-contest": "Header text displayed above the contest-creation form.",
 	"edit-contest": "Header text displayed above the contest-editing form.",

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -20,8 +20,8 @@ class HomeController extends AbstractController {
 	 */
 	public function home( ContestRepository $contestRepository, UserRepository $userRepository ): Response {
 		return $this->render( 'home.html.twig', [
-			'contests' => $contestRepository->count(),
-			'people' => $userRepository->count(),
+			'contests' => (string)$contestRepository->count(),
+			'people' => (string)$userRepository->count(),
 		] );
 	}
 }

--- a/templates/home.html.twig
+++ b/templates/home.html.twig
@@ -3,7 +3,7 @@
 {% block main %}
 
 <p class="lead">
-    {{ msg('stats-summary', [ people|number_format, contests|number_format ] ) }}
+    {{ msg('stats-summary', [ people|number_format, people, contests|number_format, contests ] ) }}
 </p>
 
 <p>


### PR DESCRIPTION
Now there are more than 1000 people, there's a comma in that
number and so it's no longer suitable for Intuition to pass to
the PLURAL parser function.