### PR TITLE
Fix wikitext output of contest scores

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -55,6 +55,8 @@
   "scores-legend": "The scores below are calculated every $1 minutes while the contest is running, and then again when the contest has ended.",
   "save-resets-scores": "Saving contest information will cause the scores to be recalculated (within $1 minutes).",
   "wikitext-scores": "Get Wikitext table of scores",
+  "url": "URL",
+  "excluded-users-none": "No excluded users.",
 
   "this-is-wscontest": "This is the Wikisource Contest tool",
   "gpl-link": "GPL 3.0+",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -52,6 +52,8 @@
 	"scores-legend": "Information text shown above the scores' table.\n\nParameters:\n\n* $1 — Interval in minutes between score re-calculations.",
 	"save-resets-scores": "Warning text below 'save' button in Contest edit form.\n\nParameters:\n\n* $1 — Interval in minutes between score re-calculations.",
 	"wikitext-scores": "Button text to get wikitext format of the contest details and scores.",
+	"url": "Label for wikitext output for a contest's full URL.",
+	"excluded-users-none": "Note text for wikitext output when there are no excluded users.",
 	"this-is-wscontest": "Footer link to the tool homepage.",
 	"gpl-link": "Footer link to the GPL license.",
 	"source-code": "Footer link to the tool's source code.",

--- a/src/Controller/ContestsController.php
+++ b/src/Controller/ContestsController.php
@@ -71,7 +71,7 @@ class ContestsController extends AbstractController {
 		Intuition $intuition,
 		int $scoreCalculationInterval,
 		string $id,
-		?string $format = null
+		?string $format = 'html'
 	): Response {
 		// Find the contest.
 		$contest = $contestRepository->get( $id );
@@ -91,19 +91,19 @@ class ContestsController extends AbstractController {
 
 		$username = $this->getLoggedInUsername( $session );
 		$canEdit = $username && $contestRepository->hasAdmin( $id, $username );
-		// $viewFormat = $request->getAttribute( 'format', 'html' );
-		// new Response();
-		// if ( $format === 'wikitext' ) {
-		// 	$response = $response->withHeader( 'Content-Type', 'text/plain' );
-		// }
-		$format = 'html';
-		return $this->render( "contests_view.$format.twig", [
+		$response = new Response();
+		if ( $format === 'wikitext' ) {
+			$response->headers->set( 'Content-Type', 'text/plain' );
+		}
+		$content = $this->renderView( "contests_view.$format.twig", [
 			'contest' => $contest,
 			'scores' => $contestRepository->getscores( $id ),
 			'can_edit' => $canEdit,
 			'can_view_scores' => $canEdit || !$contest['in_progress'],
 			'score_calculation_interval' => $scoreCalculationInterval,
 		] );
+		$response->setContent( $content );
+		return $response;
 	}
 
 	/**

--- a/templates/contests_view.wikitext.twig
+++ b/templates/contests_view.wikitext.twig
@@ -3,16 +3,20 @@
 ; {{ msg('dates') }}
 : {{ msg('start-date-label') }} {{ contest.start_date }}
 : {{ msg('end-date-label') }} {{ contest.end_date }}
+; {{ msg('url') }}
+: {{ url('contests_view', {id: contest.id}) }}
 ; {{ msg('administrators') }}
 {% for admin in contest.admins %}
 :* [[meta:User:{{ admin.name }}|{{ admin.name }}]]
 {% endfor %}
 ; {{ msg('excluded-users') }}
-{% for excluded_user in contest.excludedUsers %}
-;* [[meta:User:{{ excluded_user.name }}|{{ excluded_user.name }}]]
+{% for excluded_user in contest.excluded_users %}
+:* [[meta:User:{{ excluded_user.name }}|{{ excluded_user.name }}]]
+{% else %}
+:''{{ msg('excluded-users-none') }}''
 {% endfor %}
 ; {{ msg('index-pages') }}
-{% for ip in contest.indexPages %}
+{% for ip in contest.index_pages %}
 :* {{ ip.url }}
 {% endfor %}
 
@@ -22,10 +26,10 @@
 ! {{ msg('user') }} !! {{ msg('points') }} !! {{ msg('contributions') }} !! {{ msg('validations') }} !!
 |-
 {% for score in scores %}
-| [[meta:User:{{ score.username }}|{{ score.username }}]] || {{ score.points }} || {{ score.contributions }} || {{ score.validations }} || [{{ base_url }}{{ path('contests_view', {id: contest.id}) }}?u={{ score.user_id }} {{ msg('details') }}]
+| [[meta:User:{{ score.username }}|{{ score.username }}]] || {{ score.points }} || {{ score.contributions }} || {{ score.validations }} || [{{ url('contests_view', {id: contest.id}) }}?u={{ score.user_id }} {{ msg('details') }}]
 |-
 {% endfor %}
 |}
 {% else %}
-<div class="alert alert-success"><p>{{ msg('contest-in-progress') }}</p></div>
+{{ msg('contest-in-progress') }}
 {% endif %}


### PR DESCRIPTION
Re-enable wikitext output. It was disabled during the migration
to Symfony. Also add some extra details and fix the formatting
a bit.

Bug: https://phabricator.wikimedia.org/T315059