### PR TITLE
URL-decode index page URLs earlier, for all uses

### DIFF
--- a/src/Controller/ContestsController.php
+++ b/src/Controller/ContestsController.php
@@ -209,7 +209,7 @@ class ContestsController extends AbstractController {
 			$admins[] = $username;
 		}
 
-		$indexPageUrls = Str::explode( $request->request->get( 'index_pages' ) );
+		$indexPageUrls = array_map( 'urldecode', Str::explode( $request->request->get( 'index_pages' ) ) );
 		$indexPageResult = $indexPageRepository->saveUrls( $indexPageUrls );
 		foreach ( $indexPageResult['warnings'] as $warning ) {
 			$this->addFlash( 'warning', $warning );

--- a/src/Repository/IndexPageRepository.php
+++ b/src/Repository/IndexPageRepository.php
@@ -28,9 +28,7 @@ class IndexPageRepository extends RepositoryBase {
 		$query = $this->db->prepare( 'SELECT * FROM index_pages WHERE url = :url' );
 		$indexPageIds = [];
 		$warnings = [];
-		foreach ( $indexPageUrls as $indexPageUrlString ) {
-			$indexPageUrl = urldecode( $indexPageUrlString );
-
+		foreach ( $indexPageUrls as $indexPageUrl ) {
 			// Do we already know about it?
 			$query->bindValue( 'url', $indexPageUrl );
 			$result = $query->executeQuery();

--- a/tests/IndexPageRepositoryTest.php
+++ b/tests/IndexPageRepositoryTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Tests;
+
+use App\Repository\IndexPageRepository;
+
+class IndexPageRepositoryTest extends TestBase {
+
+	/**
+	 * @covers IndexPageRepository::saveUrls()
+	 * @dataProvider provideSaveUrls()
+	 * @return void
+	 */
+	public function testSaveUrls( $urls, $expected ) {
+		/** @var IndexPageRepository */
+		$repo = static::getContainer()->get( IndexPageRepository::class );
+		$actual = $repo->saveUrls( $urls );
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function provideSaveUrls(): array {
+		return [
+			[
+				[ 'https://jv.wikisource.org/wiki/Indhèks:Babad Saka Kitab Sutji.pdf' ],
+				[
+					'index_page_ids' => [ '1' ],
+					'warnings' => [],
+				]
+			],
+		];
+	}
+}


### PR DESCRIPTION
The list of index page URLs was only being decoded for saving them, but not for linking them to contests. This change moves the decoding up into the controller, and lets both repositories assume that the URLs are already good to go.

Bug: T331226