### PR TITLE
Handle mulwikisource in wscontest

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5790,16 +5790,16 @@
         },
         {
             "name": "wikisource/api",
-            "version": "2.0.5",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wikisource/api.git",
-                "reference": "e3a60b8251ef12538cf9aef4696fcf7c77d6ece1"
+                "reference": "c52f26051104e5289260c61a5c46c5d262719fa7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wikisource/api/zipball/e3a60b8251ef12538cf9aef4696fcf7c77d6ece1",
-                "reference": "e3a60b8251ef12538cf9aef4696fcf7c77d6ece1",
+                "url": "https://api.github.com/repos/wikisource/api/zipball/c52f26051104e5289260c61a5c46c5d262719fa7",
+                "reference": "c52f26051104e5289260c61a5c46c5d262719fa7",
                 "shasum": ""
             },
             "require": {
@@ -5835,7 +5835,7 @@
                 "issues": "https://phabricator.wikimedia.org/tag/wikisource-api/",
                 "source": "https://github.com/wikisource/api.git"
             },
-            "time": "2023-01-31T02:46:54+00:00"
+            "time": "2023-09-18T05:06:15+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Controller/ContestsController.php
+++ b/src/Controller/ContestsController.php
@@ -211,9 +211,9 @@ class ContestsController extends AbstractController {
 
 		$indexPageUrls = array_map( 'urldecode', Str::explode( $request->request->get( 'index_pages' ) ) );
 		// normalise mulwikisource URLs before saving to database
-		$normalisedIndexPageUrls = array_map(function ($url) {
-			return str_replace("https://mul.", "https://", $url);
-		}, $indexPageUrls);
+		$normalisedIndexPageUrls = array_map( static function ( $url ) {
+			return str_replace( "https://mul.", "https://", $url );
+		}, $indexPageUrls );
 		$indexPageResult = $indexPageRepository->saveUrls( $normalisedIndexPageUrls );
 		foreach ( $indexPageResult['warnings'] as $warning ) {
 			$this->addFlash( 'warning', $warning );

--- a/src/Controller/ContestsController.php
+++ b/src/Controller/ContestsController.php
@@ -210,7 +210,11 @@ class ContestsController extends AbstractController {
 		}
 
 		$indexPageUrls = array_map( 'urldecode', Str::explode( $request->request->get( 'index_pages' ) ) );
-		$indexPageResult = $indexPageRepository->saveUrls( $indexPageUrls );
+		// normalise mulwikisource URLs before saving to database
+		$normalisedIndexPageUrls = array_map(function ($url) {
+			return str_replace("https://mul.", "https://", $url);
+		}, $indexPageUrls);
+		$indexPageResult = $indexPageRepository->saveUrls( $normalisedIndexPageUrls );
 		foreach ( $indexPageResult['warnings'] as $warning ) {
 			$this->addFlash( 'warning', $warning );
 		}
@@ -223,7 +227,7 @@ class ContestsController extends AbstractController {
 			$request->request->get( 'end_date' ),
 			$admins,
 			Str::explode( $request->request->get( 'excluded_users' ) ),
-			$indexPageUrls
+			$normalisedIndexPageUrls
 		);
 
 		// Reset scores, to ensure they'll be re-calculated.

--- a/templates/contests_view.html.twig
+++ b/templates/contests_view.html.twig
@@ -44,7 +44,9 @@
 <h3 id="index_pages">{{ msg('index-pages') }}</h3>
 <ol>
     {% for ip in contest.index_pages %}
-        <li><a href="{{ ip.url }}">{{ ip.url }}</a></li>
+    {# Usually, https://mul.wikisource.org/some_page redirects to https://wikisource.org/ #}
+    {# The replace filter ensures that the link contains the correct destination, as intended, while keeping the visible URL the same #}
+        <li><a href="{{ ip.url|replace({'https://mul.': 'https://'}) }}">{{ ip.url }}</a></li>
     {% endfor %}
 </ol>
 

--- a/templates/contests_view.html.twig
+++ b/templates/contests_view.html.twig
@@ -44,9 +44,7 @@
 <h3 id="index_pages">{{ msg('index-pages') }}</h3>
 <ol>
     {% for ip in contest.index_pages %}
-    {# Usually, https://mul.wikisource.org/some_page redirects to https://wikisource.org/ #}
-    {# The replace filter ensures that the link contains the correct destination, as intended, while keeping the visible URL the same #}
-        <li><a href="{{ ip.url|replace({'https://mul.': 'https://'}) }}">{{ ip.url }}</a></li>
+        <li><a href="{{ ip.url }}">{{ ip.url }}</a></li>
     {% endfor %}
 </ol>
 


### PR DESCRIPTION
Update dependency to use the new
wikisource/api release that handles
mulwikiosurce, and apply a twig filter
to the URL being displayed

Bug: [T345325](https://phabricator.wikimedia.org/T345325)