### PR TITLE
Added contestant order in WSContest contest page

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -52,6 +52,7 @@
   "contest": "Contest: $1",
   "details": "Details",
   "unable-to-save": "Unable to save: $1",
+  "rank": "Rank",
   "user": "User",
   "points": "Points",
   "contributions": "Contributions",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -49,6 +49,7 @@
 	"contest": "Contest header. $1 is the contest name.",
 	"details": "Link to view score details of a single user.",
 	"unable-to-save": "Error message displayed when unable to save a contest. $1 is the reason.",
+	"rank": "Table header of the user details' table.",
 	"user": "Table header of the user details' table.",
 	"points": "Table header of the user details' table.",
 	"contributions": "Table header of the user details' table.\n\n{{Identical|Contribution}}",

--- a/templates/contests_view.html.twig
+++ b/templates/contests_view.html.twig
@@ -55,6 +55,7 @@
             <caption style="caption-side: top">{{ msg('scores-legend', [score_calculation_interval~'']) }}</caption>
             <thead>
                 <tr>
+                    <th>{{ msg('rank') }}</th>
                     <th>{{ msg('user') }}</th>
                     <th>{{ msg('points') }}</th>
                     <th>{{ msg('contributions') }}</th>
@@ -63,8 +64,9 @@
                 </tr>
             </thead>
             <tbody>
-            {% for score in scores %}
+            {% for index, score in scores %}
                 <tr>
+                    <td>{{ index + 1 }}</td>
                     <td><a href="https://meta.wikimedia.org/wiki/User:{{ score.username }}">{{ score.username }}</a></td>
                     <td>{{ score.points }}</td>
                     <td>{{ score.contributions }}</td>


### PR DESCRIPTION
Added contestant order in WSContest contest page

I have added contestant rank on the contest page of WSContest. It will be beneficial to the contestant as well as admins to be able to tell, for example: who are the top 10 contestant, how many total contestants are there, etc. 

Feature: T331507 (https://phabricator.wikimedia.org/T331507)