### PR TITLE
Update messages shown when deleting a contest

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -98,8 +98,9 @@
 
   "delete": "Delete",
   "tip": "TIP",
-  "click-here-link": "Click here",
-  "save-scores-before-delete": "to save your scores as wikitext before deleting your contest",
+  "save-scores": "You may wish to $1 before deleting your contest.",
+  "save-scores-link": "save your scores as wikitext",
+  "save-scores-tooltip": "Link opens in a new tab",
   "confirm-delete-text": "Please confirm that you want to delete",
   "do-not-delete": "Don't delete",
   "confirm-delete": "Yes, I confirm"

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -93,8 +93,9 @@
 	"delete-contest": "Button text to delete a contest",
 	"delete": "Label for the modal title",
 	"tip": "Label for the tip",
-	"click-here-link": "Text displayed on the URL to retrieve scores as wikitext before deletion",
-	"save-scores-before-delete": "Text that prompts the user to save scores of the contest before deletion",
+	"save-scores": "Text that prompts the user to save scores of the contest before deletion.\n\nParameter:\n* $1 — HTML link with {{msg|save-scores-link}} as its label.",
+	"save-scores-link": "Link text that's inserted into {{msg|save-scores}}.",
+	"save-scores-tooltip": "Link title text for the link inserted into {{msg|save-scores}}.",
 	"confirm-delete-text": "Text that asks confirmation from the user for contest deletion",
 	"do-not-delete": "Button text that cancels the deletion process",
 	"confirm-delete": "Button text that confirms and initiates the deletion process"

--- a/templates/contests_edit.html.twig
+++ b/templates/contests_edit.html.twig
@@ -83,9 +83,15 @@
                 </div>
                 <div class="modal-body">
                     {% if scoresExist == true %}
-                        <p><span class='border border-2 border-dark fw-bold rounded px-1'>{{ msg('tip') }}</span>
-                        <a href="{{ path('contests_view', {id: contest.id, format: 'wikitext'}) }}">{{ msg('click-here-link') }}</a>
-                        {{ msg('save-scores-before-delete') }}</p>
+                        <p>
+                            <span class='border border-2 border-dark fw-bold rounded px-1'>{{ msg('tip') }}</span>
+                            {% set save_scores_link %}
+                                <a href="{{ path('contests_view', {id: contest.id, format: 'wikitext'}) }}" title="{{ msg('save-scores-tooltip') }}" target="_blank">
+                                    {{ msg('save-scores-link') }}
+                                </a>
+                            {% endset %}
+                            {{ msg('save-scores', [save_scores_link])|raw }}
+                        </p>
                     {% endif %}
                     <p class="text-danger">{{ msg('confirm-delete-text') }} <span class="fw-bold">{{contest.name}}</span></p>
                 </div>


### PR DESCRIPTION
This avoids the 'click here' message by embedding a link into the sentence.

Bug: T367634