### PR TITLE
Return index page warning in correct structure

### DIFF
--- a/src/Repository/IndexPageRepository.php
+++ b/src/Repository/IndexPageRepository.php
@@ -46,7 +46,7 @@ class IndexPageRepository extends RepositoryBase {
 			try {
 				$wsIndexPage = $wikisource->getIndexPageFromUrl( $indexPageUrl );
 			} catch ( WikisourceApiException $e ) {
-				$warnings[] = $e->getMessage();
+				$warnings[] = [ 'unable-to-save', [ $e->getMessage() ] ];
 				continue;
 			}
 			if ( !$wsIndexPage->loaded() ) {


### PR DESCRIPTION
Fix the WikisourceApiException warning reporting to use the same structure as other warnings. It looks like this was always supposed to be the case, because the `unable-to-save` message already exists but wasn't actuall being used.

Bug: T391310